### PR TITLE
Feat: Player view shakes when hit by laser

### DIFF
--- a/Assets/_Project No Physics/Scripts/PlayerInfo.cs
+++ b/Assets/_Project No Physics/Scripts/PlayerInfo.cs
@@ -22,17 +22,21 @@ public class PlayerInfo : NetworkBehaviour
     [SyncVar]
     public int kills;
 
+    // Camera Shake
+    public float camShakeDuration = 0.2f;
+    public float camShakeMagnitude = 0.5f;
+    private Camera playerCam;
 
     // UI Elements
     public Text healthText;
     public Text scoreText;
 
-        Material newMaterial;
+    Material newMaterial;
     void Start()
     {
-        //playerHealth = rnd.Next(50, 101);
         playerHealth = maxHealth;
         playerScore = rnd.Next(1, 10001);
+        playerCam = GetComponentInChildren<Camera>();
         changeColor();
     }
 
@@ -85,6 +89,34 @@ public class PlayerInfo : NetworkBehaviour
     {
         playerHealth -= damage;
         changeColor();
+        StartCoroutine(ShakeCam());
+    }
+
+    private IEnumerator ShakeCam()
+    {
+        float elapsed = 0.0f;
+
+        Vector3 originalCamPosition = playerCam.transform.localPosition;
+
+        while (elapsed < camShakeDuration)
+        {
+            elapsed += Time.deltaTime;
+
+            float percentComplete = elapsed / camShakeDuration;
+            float damper = 1.0f - Mathf.Clamp(4.0f * percentComplete - 3.0f, 0.0f, 1.0f);
+
+            // Map value to [-1, 1]
+            float x = Random.value * 2.0f - 1.0f;
+            float y = Random.value * 2.0f - 1.0f;
+            x *= camShakeMagnitude * damper;
+            y *= camShakeMagnitude * damper;
+
+            playerCam.transform.localPosition = new Vector3(x, y, originalCamPosition.z);
+
+            yield return null;
+        }
+
+        playerCam.transform.localPosition = originalCamPosition;
     }
 
     public int getHealth ()

--- a/ProjectSettings/GraphicsSettings.asset
+++ b/ProjectSettings/GraphicsSettings.asset
@@ -37,6 +37,7 @@ GraphicsSettings:
   - {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 16000, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 17000, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 16001, guid: 0000000000000000f000000000000000, type: 0}
   m_PreloadedShaders: []
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
     type: 0}


### PR DESCRIPTION
- When hit by another player's laser, local player's camera view shakes violently as if they were experiencing the searing pain of being struck by a concentrated beam of pure energy